### PR TITLE
Creating new dreams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
-laguange: java
+language: java
 jdk:
   - oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
   ext {
     kotlinVersion = '1.2.51'
     springBootVersion = '2.0.5.RELEASE'
+    kotlintestVersion = "3.1.10"
   }
   repositories {
     mavenCentral()
@@ -65,8 +66,8 @@ dependencies {
   
   testImplementation('org.springframework.boot:spring-boot-starter-test')
   testImplementation('org.springframework.security:spring-security-test')
-  testImplementation "io.kotlintest:kotlintest-runner-junit5:3.1.8"
-  testImplementation "io.kotlintest:kotlintest-assertions-arrow:3.1.8"
+  testImplementation "io.kotlintest:kotlintest-runner-junit5:$kotlintestVersion"
+  testImplementation "io.kotlintest:kotlintest-assertions-arrow:$kotlintestVersion"
 
   ktlint "com.github.shyiko:ktlint:0.20.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,8 @@ dependencies {
 
   ktlint "com.github.shyiko:ktlint:0.20.0"
 
+  implementation "io.arrow-kt:arrow-core:0.7.3"
+
   implementation "io.springfox:springfox-swagger2:2.9.2"
   implementation "io.springfox:springfox-swagger-ui:2.9.2"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ repositories {
   mavenCentral()
 }
 
+test {
+  useJUnitPlatform()
+}
+
 configurations {
   ktlint
 }
@@ -58,8 +62,11 @@ dependencies {
   implementation("org.jetbrains.kotlin:kotlin-reflect")
   runtimeOnly('org.springframework.boot:spring-boot-devtools')
   runtimeOnly('com.h2database:h2')
+  
   testImplementation('org.springframework.boot:spring-boot-starter-test')
   testImplementation('org.springframework.security:spring-security-test')
+  testImplementation "io.kotlintest:kotlintest-runner-junit5:3.1.8"
+  testImplementation "io.kotlintest:kotlintest-assertions-arrow:3.1.8"
 
   ktlint "com.github.shyiko:ktlint:0.20.0"
 

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/DreamController.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/DreamController.kt
@@ -1,0 +1,22 @@
+package com.infusionvlc.somniumserver.dreams
+
+import com.infusionvlc.somniumserver.dreams.models.Dream
+import com.infusionvlc.somniumserver.dreams.usecases.GetAllDreams
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/dreams/v1")
+class DreamController(
+  private val getAllDreams: GetAllDreams
+) {
+
+  @GetMapping("/")
+  fun getAll(@RequestParam("page") page: Int,
+             @RequestParam("page_size") pageSize: Int): ResponseEntity<List<Dream>> =
+    ResponseEntity.ok(getAllDreams.execute(page, pageSize))
+
+}

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/DreamController.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/DreamController.kt
@@ -6,7 +6,10 @@ import com.infusionvlc.somniumserver.dreams.models.DreamRequest
 import com.infusionvlc.somniumserver.dreams.usecases.CreateDream
 import com.infusionvlc.somniumserver.dreams.usecases.GetAllDreams
 import com.infusionvlc.somniumserver.users.security.models.SecurityUser
-import io.swagger.annotations.*
+import io.swagger.annotations.Api
+import io.swagger.annotations.ApiOperation
+import io.swagger.annotations.ApiResponse
+import io.swagger.annotations.ApiResponses
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
@@ -31,8 +34,10 @@ class DreamController(
   @ApiResponses(
     ApiResponse(code = 200, response = Dream::class, responseContainer = "List", message = "Feed of dreams")
   )
-  fun getAll(@RequestParam("page") page: Int,
-             @RequestParam("page_size") pageSize: Int): ResponseEntity<List<Dream>> =
+  fun getAll(
+    @RequestParam("page") page: Int,
+    @RequestParam("page_size") pageSize: Int
+  ): ResponseEntity<List<Dream>> =
     ResponseEntity.ok(getAllDreams.execute(page, pageSize))
 
   @PostMapping("/")
@@ -41,8 +46,10 @@ class DreamController(
     ApiResponse(code = 201, response = Dream::class, message = ""),
     ApiResponse(code = 400, message = "Validation error message")
   )
-  fun createDream(@RequestBody dreamRequest: DreamRequest,
-                  @ApiIgnore authentication: Authentication): ResponseEntity<*> {
+  fun createDream(
+    @RequestBody dreamRequest: DreamRequest,
+    @ApiIgnore authentication: Authentication
+  ): ResponseEntity<*> {
     val requestUser = authentication.principal as SecurityUser
     return createDream.execute(dreamRequest, requestUser.id)
       .fold(
@@ -59,5 +66,4 @@ class DreamController(
         { ResponseEntity(it, HttpStatus.CREATED) }
       )
   }
-
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/DreamController.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/DreamController.kt
@@ -1,9 +1,18 @@
 package com.infusionvlc.somniumserver.dreams
 
 import com.infusionvlc.somniumserver.dreams.models.Dream
+import com.infusionvlc.somniumserver.dreams.models.DreamCreationErrors
+import com.infusionvlc.somniumserver.dreams.models.DreamRequest
+import com.infusionvlc.somniumserver.dreams.usecases.CreateDream
 import com.infusionvlc.somniumserver.dreams.usecases.GetAllDreams
+import com.infusionvlc.somniumserver.users.security.models.SecurityUser
+import com.infusionvlc.somniumserver.users.usecases.FindUserByUsername
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -11,12 +20,37 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/dreams/v1")
 class DreamController(
-  private val getAllDreams: GetAllDreams
+  private val getAllDreams: GetAllDreams,
+  private val createDream: CreateDream,
+  private val findUserByUsername: FindUserByUsername
 ) {
 
   @GetMapping("/")
   fun getAll(@RequestParam("page") page: Int,
              @RequestParam("page_size") pageSize: Int): ResponseEntity<List<Dream>> =
     ResponseEntity.ok(getAllDreams.execute(page, pageSize))
+
+  @PostMapping("/")
+  fun createDream(@RequestBody dreamRequest: DreamRequest,
+                  authentication: Authentication): ResponseEntity<*> {
+    val requestUser = authentication.principal as SecurityUser
+    val user = findUserByUsername.execute(requestUser.username)
+
+    val result = createDream.execute(dreamRequest, user.id)
+      .fold(
+        {
+          ResponseEntity(when (it) {
+            is DreamCreationErrors.TitleTooLong -> "Title is too long"
+            is DreamCreationErrors.DescriptionTooLong -> "Description is too long"
+            is DreamCreationErrors.TitleMisssing -> "Title is missing"
+            is DreamCreationErrors.DescriptionMissing -> "Description is missing"
+            is DreamCreationErrors.InvalidDate -> "Invalid dreamt date"
+          }, HttpStatus.BAD_REQUEST)
+        },
+        { ResponseEntity(it, HttpStatus.CREATED) }
+      )
+
+    return ResponseEntity(result, HttpStatus.CREATED)
+  }
 
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/Dream.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/Dream.kt
@@ -1,0 +1,11 @@
+package com.infusionvlc.somniumserver.dreams.models
+
+data class Dream(
+  val id: Long,
+  val title: String,
+  val description: String,
+  val userId: Long,
+  val creationDate: Long,
+  val updateDate: Long,
+  val dreamtDate: Long
+)

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamCreationErrors.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamCreationErrors.kt
@@ -3,7 +3,8 @@ package com.infusionvlc.somniumserver.dreams.models
 sealed class DreamCreationErrors {
   object TitleTooLong : DreamCreationErrors()
   object DescriptionTooLong : DreamCreationErrors()
-  object TitleMisssing : DreamCreationErrors()
+  object TitleMissing : DreamCreationErrors()
   object DescriptionMissing : DreamCreationErrors()
   object InvalidDate : DreamCreationErrors()
+  class CreatorNotFound(val userId: Long) : DreamCreationErrors()
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamCreationErrors.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamCreationErrors.kt
@@ -1,0 +1,9 @@
+package com.infusionvlc.somniumserver.dreams.models
+
+sealed class DreamCreationErrors {
+  object TitleTooLong : DreamCreationErrors()
+  object DescriptionTooLong : DreamCreationErrors()
+  object TitleMisssing : DreamCreationErrors()
+  object DescriptionMissing : DreamCreationErrors()
+  object InvalidDate : DreamCreationErrors()
+}

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamRequest.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamRequest.kt
@@ -15,4 +15,3 @@ fun DreamRequest.toDomain(userId: Long): Dream = Dream(
   updateDate = System.currentTimeMillis(),
   dreamtDate = this.dreamtDate
 )
-

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamRequest.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamRequest.kt
@@ -1,0 +1,18 @@
+package com.infusionvlc.somniumserver.dreams.models
+
+data class DreamRequest(
+  val title: String = "",
+  val description: String = "",
+  val dreamtDate: Long = 0
+)
+
+fun DreamRequest.toDomain(userId: Long): Dream = Dream(
+  id = 0,
+  title = this.title,
+  description = this.description,
+  userId = userId,
+  creationDate = System.currentTimeMillis(),
+  updateDate = System.currentTimeMillis(),
+  dreamtDate = this.dreamtDate
+)
+

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/persistence/DreamEntity.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/persistence/DreamEntity.kt
@@ -31,3 +31,7 @@ fun DreamEntity.toDomain(): Dream = Dream(
   updateDate = this.updateDate,
   dreamtDate = this.dreamtDate
 )
+
+fun Dream.toEntity(): DreamEntity = DreamEntity(
+  id, title, description, creationDate, updateDate, dreamtDate
+)

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/persistence/DreamEntity.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/persistence/DreamEntity.kt
@@ -1,0 +1,33 @@
+package com.infusionvlc.somniumserver.dreams.persistence
+
+import com.infusionvlc.somniumserver.dreams.models.Dream
+import com.infusionvlc.somniumserver.users.persistence.UserEntity
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "Dreams")
+data class DreamEntity(
+  @Id @GeneratedValue(strategy = GenerationType.AUTO) val id: Long = 0,
+  val title: String = "",
+  val description: String = "",
+  val creationDate: Long = 0,
+  val updateDate: Long = 0,
+  val dreamtDate: Long = 0,
+
+  @ManyToOne val user: UserEntity = UserEntity()
+)
+
+fun DreamEntity.toDomain(): Dream = Dream(
+  id = this.id,
+  title = this.title,
+  description = this.description,
+  userId = this.user.id,
+  creationDate = this.creationDate,
+  updateDate = this.updateDate,
+  dreamtDate = this.dreamtDate
+)

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/persistence/DreamEntity.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/persistence/DreamEntity.kt
@@ -1,13 +1,10 @@
 package com.infusionvlc.somniumserver.dreams.persistence
 
 import com.infusionvlc.somniumserver.dreams.models.Dream
+import com.infusionvlc.somniumserver.users.models.User
 import com.infusionvlc.somniumserver.users.persistence.UserEntity
-import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.GenerationType
-import javax.persistence.Id
-import javax.persistence.ManyToOne
-import javax.persistence.Table
+import com.infusionvlc.somniumserver.users.persistence.toEntity
+import javax.persistence.*
 
 @Entity
 @Table(name = "Dreams")
@@ -19,7 +16,9 @@ data class DreamEntity(
   val updateDate: Long = 0,
   val dreamtDate: Long = 0,
 
-  @ManyToOne val user: UserEntity = UserEntity()
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  val user: UserEntity = UserEntity()
 )
 
 fun DreamEntity.toDomain(): Dream = Dream(
@@ -32,6 +31,6 @@ fun DreamEntity.toDomain(): Dream = Dream(
   dreamtDate = this.dreamtDate
 )
 
-fun Dream.toEntity(): DreamEntity = DreamEntity(
-  id, title, description, creationDate, updateDate, dreamtDate
+fun Dream.toEntity(user: User): DreamEntity = DreamEntity(
+  id, title, description, creationDate, updateDate, dreamtDate, user.toEntity()
 )

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/persistence/DreamEntity.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/persistence/DreamEntity.kt
@@ -4,7 +4,14 @@ import com.infusionvlc.somniumserver.dreams.models.Dream
 import com.infusionvlc.somniumserver.users.models.User
 import com.infusionvlc.somniumserver.users.persistence.UserEntity
 import com.infusionvlc.somniumserver.users.persistence.toEntity
-import javax.persistence.*
+import javax.persistence.Entity
+import javax.persistence.FetchType
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
 
 @Entity
 @Table(name = "Dreams")

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/persistence/DreamRepository.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/persistence/DreamRepository.kt
@@ -1,0 +1,5 @@
+package com.infusionvlc.somniumserver.dreams.persistence
+
+import org.springframework.data.repository.PagingAndSortingRepository
+
+interface DreamRepository : PagingAndSortingRepository<DreamEntity, Long>

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDream.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDream.kt
@@ -1,6 +1,7 @@
 package com.infusionvlc.somniumserver.dreams.usecases
 
 import arrow.core.Either
+import arrow.core.flatMap
 import arrow.core.left
 import arrow.core.right
 import com.infusionvlc.somniumserver.dreams.models.Dream
@@ -10,27 +11,33 @@ import com.infusionvlc.somniumserver.dreams.models.toDomain
 import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
 import com.infusionvlc.somniumserver.dreams.persistence.toDomain
 import com.infusionvlc.somniumserver.dreams.persistence.toEntity
+import com.infusionvlc.somniumserver.users.usecases.FindUserById
 import org.springframework.stereotype.Component
 
 @Component
 class CreateDream(
-  private val dao: DreamRepository
+  private val dao: DreamRepository,
+  private val findUserById: FindUserById
 ) {
-  fun execute(dreamRequest: DreamRequest, userId: Long): Either<DreamCreationErrors, Dream> {
-    val dream = dreamRequest.toDomain(userId)
-    val validationResult = validate(dream)
-
-    return validationResult
-      .map { dao.save(it.toEntity()) }
+  fun execute(
+    dreamRequest: DreamRequest,
+    userId: Long,
+    currentTime: Long = System.currentTimeMillis()
+  ): Either<DreamCreationErrors, Dream> =
+    validate(dreamRequest.toDomain(userId), currentTime)
+      .flatMap { dream ->
+        findUserById.execute(userId)
+          .toEither { DreamCreationErrors.CreatorNotFound(userId) }
+          .map { user -> dao.save(dream.toEntity(user)) }
+      }
       .map { it.toDomain() }
-  }
 
-  private fun validate(dream: Dream): Either<DreamCreationErrors, Dream> = when {
+  private fun validate(dream: Dream, currentTime: Long): Either<DreamCreationErrors, Dream> = when {
     dream.title.length >= 40 -> DreamCreationErrors.TitleTooLong.left()
-    dream.title.isBlank() -> DreamCreationErrors.TitleMisssing.left()
+    dream.title.isBlank() -> DreamCreationErrors.TitleMissing.left()
     dream.description.length >= 200 -> DreamCreationErrors.DescriptionTooLong.left()
     dream.description.isBlank() -> DreamCreationErrors.DescriptionMissing.left()
-    dream.dreamtDate >= System.currentTimeMillis() -> DreamCreationErrors.InvalidDate.left()
+    dream.dreamtDate > currentTime -> DreamCreationErrors.InvalidDate.left()
     else -> dream.right()
   }
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDream.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDream.kt
@@ -33,9 +33,9 @@ class CreateDream(
       .map { it.toDomain() }
 
   private fun validate(dream: Dream, currentTime: Long): Either<DreamCreationErrors, Dream> = when {
-    dream.title.length >= 40 -> DreamCreationErrors.TitleTooLong.left()
+    dream.title.length > 40 -> DreamCreationErrors.TitleTooLong.left()
     dream.title.isBlank() -> DreamCreationErrors.TitleMissing.left()
-    dream.description.length >= 200 -> DreamCreationErrors.DescriptionTooLong.left()
+    dream.description.length > 200 -> DreamCreationErrors.DescriptionTooLong.left()
     dream.description.isBlank() -> DreamCreationErrors.DescriptionMissing.left()
     dream.dreamtDate > currentTime -> DreamCreationErrors.InvalidDate.left()
     else -> dream.right()

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDream.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDream.kt
@@ -1,0 +1,36 @@
+package com.infusionvlc.somniumserver.dreams.usecases
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.infusionvlc.somniumserver.dreams.models.Dream
+import com.infusionvlc.somniumserver.dreams.models.DreamCreationErrors
+import com.infusionvlc.somniumserver.dreams.models.DreamRequest
+import com.infusionvlc.somniumserver.dreams.models.toDomain
+import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
+import com.infusionvlc.somniumserver.dreams.persistence.toDomain
+import com.infusionvlc.somniumserver.dreams.persistence.toEntity
+import org.springframework.stereotype.Component
+
+@Component
+class CreateDream(
+  private val dao: DreamRepository
+) {
+  fun execute(dreamRequest: DreamRequest, userId: Long): Either<DreamCreationErrors, Dream> {
+    val dream = dreamRequest.toDomain(userId)
+    val validationResult = validate(dream)
+
+    return validationResult
+      .map { dao.save(it.toEntity()) }
+      .map { it.toDomain() }
+  }
+
+  private fun validate(dream: Dream): Either<DreamCreationErrors, Dream> = when {
+    dream.title.length >= 40 -> DreamCreationErrors.TitleTooLong.left()
+    dream.title.isBlank() -> DreamCreationErrors.TitleMisssing.left()
+    dream.description.length >= 200 -> DreamCreationErrors.DescriptionTooLong.left()
+    dream.description.isBlank() -> DreamCreationErrors.DescriptionMissing.left()
+    dream.dreamtDate >= System.currentTimeMillis() -> DreamCreationErrors.InvalidDate.left()
+    else -> dream.right()
+  }
+}

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/GetAllDreams.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/GetAllDreams.kt
@@ -1,0 +1,17 @@
+package com.infusionvlc.somniumserver.dreams.usecases
+
+import com.infusionvlc.somniumserver.dreams.models.Dream
+import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
+import com.infusionvlc.somniumserver.dreams.persistence.toDomain
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Component
+
+@Component
+class GetAllDreams(
+  private val dao: DreamRepository
+) {
+  fun execute(page: Int, pageSize: Int): List<Dream> =
+    dao.findAll(PageRequest.of(page, pageSize))
+      .map { it.toDomain() }
+      .toList()
+}

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/AuthenticationController.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/AuthenticationController.kt
@@ -41,5 +41,4 @@ class AuthenticationController(
     val user = registerUser.execute(request)
     return ResponseEntity(user.toResponse(), HttpStatus.CREATED)
   }
-
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/models/Role.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/models/Role.kt
@@ -5,6 +5,6 @@ data class Role (
   val name: String
 ) {
   companion object {
-    fun userRole(): Role = Role(1, "user")
+    fun userRole(): Role = Role(1, "USER")
   }
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/models/User.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/models/User.kt
@@ -4,5 +4,5 @@ data class User(
   val id: Long,
   val username: String,
   val password: String,
-  val role: Role
+  val role: Role = Role.userRole()
 )

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/models/UserNotFoundError.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/models/UserNotFoundError.kt
@@ -1,0 +1,7 @@
+package com.infusionvlc.somniumserver.users.models
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+object UserNotFoundError : RuntimeException("Bad username or password")

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/persistence/UserEntity.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/persistence/UserEntity.kt
@@ -1,12 +1,8 @@
 package com.infusionvlc.somniumserver.users.persistence
 
 import com.infusionvlc.somniumserver.dreams.persistence.DreamEntity
-import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.GenerationType
-import javax.persistence.Id
-import javax.persistence.OneToMany
-import javax.persistence.Table
+import com.infusionvlc.somniumserver.users.models.User
+import javax.persistence.*
 
 @Entity
 @Table(name = "Users")
@@ -15,5 +11,22 @@ data class UserEntity(
   val username: String = "",
   val password: String = "",
 
-  @OneToMany(mappedBy = "user") val dreams: List<DreamEntity> = emptyList()
+  @OneToMany(
+    mappedBy = "user",
+    cascade = [CascadeType.ALL],
+    orphanRemoval = true
+  )
+  val dreams: List<DreamEntity> = emptyList()
+)
+
+fun UserEntity.toDomain(): User = User(
+  id = id,
+  username = username,
+  password = password
+)
+
+fun User.toEntity(): UserEntity = UserEntity(
+  id = id,
+  username = username,
+  password = password
 )

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/persistence/UserEntity.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/persistence/UserEntity.kt
@@ -2,7 +2,13 @@ package com.infusionvlc.somniumserver.users.persistence
 
 import com.infusionvlc.somniumserver.dreams.persistence.DreamEntity
 import com.infusionvlc.somniumserver.users.models.User
-import javax.persistence.*
+import javax.persistence.CascadeType
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.OneToMany
+import javax.persistence.Table
 
 @Entity
 @Table(name = "Users")

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/persistence/UserEntity.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/persistence/UserEntity.kt
@@ -1,0 +1,19 @@
+package com.infusionvlc.somniumserver.users.persistence
+
+import com.infusionvlc.somniumserver.dreams.persistence.DreamEntity
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.OneToMany
+import javax.persistence.Table
+
+@Entity
+@Table(name = "Users")
+data class UserEntity(
+  @Id @GeneratedValue(strategy = GenerationType.AUTO) val id: Long = 0,
+  val username: String = "",
+  val password: String = "",
+
+  @OneToMany(mappedBy = "user") val dreams: List<DreamEntity> = emptyList()
+)

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/persistence/UserRepository.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/persistence/UserRepository.kt
@@ -1,0 +1,7 @@
+package com.infusionvlc.somniumserver.users.persistence
+
+import org.springframework.data.repository.CrudRepository
+
+interface UserRepository : CrudRepository<UserEntity, Long> {
+  fun findByUsername(username: String): UserEntity?
+}

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/security/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/security/CustomUserDetailsService.kt
@@ -1,5 +1,6 @@
 package com.infusionvlc.somniumserver.users.security
 
+import com.infusionvlc.somniumserver.users.models.UserNotFoundError
 import com.infusionvlc.somniumserver.users.security.models.toSecurity
 import com.infusionvlc.somniumserver.users.usecases.FindUserByUsername
 import org.springframework.security.core.userdetails.UserDetails
@@ -11,6 +12,12 @@ class CustomUserDetailsService(
   private val findUserByUsername: FindUserByUsername
 ) : UserDetailsService {
 
-  override fun loadUserByUsername(username: String): UserDetails =
-    findUserByUsername.execute(username).toSecurity()
+  override fun loadUserByUsername(username: String): UserDetails {
+    val option = findUserByUsername.execute(username)
+    if (option.isDefined()) {
+      return option.get().toSecurity()
+    } else {
+      throw UserNotFoundError
+    }
+  }
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/security/TokenBasedAuthentication.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/security/TokenBasedAuthentication.kt
@@ -5,8 +5,9 @@ import org.springframework.security.core.userdetails.UserDetails
 
 class TokenBasedAuthentication(
   private val userDetails: UserDetails,
-  private val token: String
+  val token: String
 ) : AbstractAuthenticationToken(userDetails.authorities) {
   override fun getCredentials() = token
   override fun getPrincipal() = userDetails
+  override fun isAuthenticated(): Boolean = true
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/security/TokenHelper.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/security/TokenHelper.kt
@@ -4,7 +4,7 @@ import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import org.springframework.stereotype.Component
-import java.util.*
+import java.util.Date
 import javax.servlet.http.HttpServletRequest
 
 @Component

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/security/WebSecurityConfig.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/security/WebSecurityConfig.kt
@@ -58,5 +58,4 @@ class WebSecurityConfig(
       .csrf().disable()
       .exceptionHandling().authenticationEntryPoint(unauthorizedHandler)
   }
-
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/security/WebSecurityConfig.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/security/WebSecurityConfig.kt
@@ -3,6 +3,7 @@ package com.infusionvlc.somniumserver.users.security
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.config.BeanIds
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
@@ -46,10 +47,15 @@ class WebSecurityConfig(
       .antMatchers("/v2/api-docs/**").permitAll()
       .antMatchers("/swagger**/**").permitAll()
       .antMatchers("/webjars/**").permitAll()
-      .anyRequest().authenticated().and()
+      .antMatchers("/h2-console/**").permitAll()
+      .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+      .anyRequest().authenticated()
+      .and()
+      .headers().frameOptions().sameOrigin()
+      .and()
       .addFilterBefore(TokenAuthenticationFilter(tokenHelper, userDetailsService),
         UsernamePasswordAuthenticationFilter::class.java)
-      .csrf().and()
+      .csrf().disable()
       .exceptionHandling().authenticationEntryPoint(unauthorizedHandler)
   }
 

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/security/models/SecurityUser.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/security/models/SecurityUser.kt
@@ -3,9 +3,10 @@ package com.infusionvlc.somniumserver.users.security.models
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
-data class SecurityUser(
-  private val name: String = "",
-  private val pswd: String = "",
+class SecurityUser(
+  val id: Long = 0,
+  private val username: String = "",
+  private val password: String = "",
   private val roles: List<Authority> = emptyList()
 ) : UserDetails {
 
@@ -13,11 +14,11 @@ data class SecurityUser(
 
   override fun isEnabled(): Boolean = true
 
-  override fun getUsername(): String = name
+  override fun getUsername(): String = username
 
   override fun isCredentialsNonExpired(): Boolean = true
 
-  override fun getPassword(): String = pswd
+  override fun getPassword(): String = password
 
   override fun isAccountNonExpired(): Boolean = true
 

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/security/models/mappings.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/security/models/mappings.kt
@@ -2,9 +2,9 @@ package com.infusionvlc.somniumserver.users.security.models
 
 import com.infusionvlc.somniumserver.users.models.Role
 import com.infusionvlc.somniumserver.users.models.User
-import org.springframework.security.core.userdetails.UserDetails
 
 fun User.toSecurity(): SecurityUser = SecurityUser(
+  id,
   username,
   password,
   listOf(role.toAuthority())

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/usecases/FindUserById.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/usecases/FindUserById.kt
@@ -7,11 +7,8 @@ import com.infusionvlc.somniumserver.users.persistence.toDomain
 import org.springframework.stereotype.Component
 
 @Component
-class FindUserByUsername(
-  private val dao: UserRepository
-) {
-  fun execute(username: String): Option<User> = Option
-    .fromNullable(dao.findByUsername(username))
+class FindUserById(private val dao: UserRepository) {
+  fun execute(id: Long): Option<User> = Option
+    .fromNullable(dao.findById(id).orElseGet { null })
     .map { it.toDomain() }
-
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/usecases/FindUserByUsername.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/usecases/FindUserByUsername.kt
@@ -13,5 +13,4 @@ class FindUserByUsername(
   fun execute(username: String): Option<User> = Option
     .fromNullable(dao.findByUsername(username))
     .map { it.toDomain() }
-
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/users/usecases/RegisterUser.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/users/usecases/RegisterUser.kt
@@ -3,24 +3,32 @@ package com.infusionvlc.somniumserver.users.usecases
 import com.infusionvlc.somniumserver.users.models.RegisterRequest
 import com.infusionvlc.somniumserver.users.models.Role
 import com.infusionvlc.somniumserver.users.models.User
+import com.infusionvlc.somniumserver.users.persistence.UserRepository
+import com.infusionvlc.somniumserver.users.persistence.toDomain
+import com.infusionvlc.somniumserver.users.persistence.toEntity
 import org.springframework.context.annotation.Bean
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Component
 
 @Component
-class RegisterUser {
+class RegisterUser(
+  private val dao: UserRepository
+) {
 
   @Bean
   fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
 
   fun execute(registerRequest: RegisterRequest): User {
     val (username, password) = registerRequest
-    return User(
+    val userEntity = User(
       0,
       username,
       passwordEncoder().encode(password),
       Role.userRole()
-    )
+    ).toEntity()
+
+    val result = dao.save(userEntity)
+    return result.toDomain()
   }
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,2 @@
+cors.allowedOrigin=http://localhost:3000
+spring.datasource.platform=h2

--- a/src/test/kotlin/com/infusionvlc/somniumserver/SomniumServerApplicationTests.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/SomniumServerApplicationTests.kt
@@ -12,5 +12,4 @@ class SomniumServerApplicationTests {
   @Test
   fun contextLoads() {
   }
-
 }

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDreamTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDreamTest.kt
@@ -100,6 +100,5 @@ class CreateDreamTest : StringSpec() {
       createDream.execute(dreamRequest, 0, 2000)
         .shouldBeRight()
     }
-
   }
 }

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDreamTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDreamTest.kt
@@ -1,0 +1,105 @@
+package com.infusionvlc.somniumserver.dreams.usecases
+
+import arrow.core.Either
+import arrow.core.Option
+import com.infusionvlc.somniumserver.dreams.models.DreamCreationErrors
+import com.infusionvlc.somniumserver.dreams.models.DreamRequest
+import com.infusionvlc.somniumserver.dreams.persistence.DreamEntity
+import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
+import com.infusionvlc.somniumserver.mock
+import com.infusionvlc.somniumserver.users.models.User
+import com.infusionvlc.somniumserver.users.usecases.FindUserById
+import io.kotlintest.assertions.arrow.either.shouldBeLeft
+import io.kotlintest.assertions.arrow.either.shouldBeRight
+import io.kotlintest.assertions.arrow.either.shouldNotBeRight
+import io.kotlintest.matchers.types.shouldBeTypeOf
+import io.kotlintest.specs.StringSpec
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.Mockito.`when`
+
+class CreateDreamTest : StringSpec() {
+
+  private val mockDao = mock<DreamRepository>()
+  private val mockFindUser = mock<FindUserById>()
+  private val createDream = CreateDream(mockDao, mockFindUser)
+
+  private fun findUserMockWillReturnUser() {
+    `when`(mockFindUser.execute(anyLong())).thenReturn(Option.just(User(0, "test", "test")))
+  }
+
+  private fun findUserMockWillReturnEmpty() {
+    `when`(mockFindUser.execute(anyLong())).thenReturn(Option.empty())
+  }
+
+  init {
+
+    "If dream title is empty an error should be returned" {
+      findUserMockWillReturnUser()
+
+      val emptyTitleDreamRequest = DreamRequest(description = "Test", dreamtDate = 1000)
+
+      createDream.execute(emptyTitleDreamRequest, 2000)
+        .shouldBeLeft(DreamCreationErrors.TitleMissing)
+    }
+
+    "If dream description is empty an error should be returned" {
+      findUserMockWillReturnUser()
+
+      val emptyTitleDreamRequest = DreamRequest(title = "Test", dreamtDate = 1000)
+
+      createDream.execute(emptyTitleDreamRequest, 0, 2000)
+        .shouldBeLeft(DreamCreationErrors.DescriptionMissing)
+    }
+
+    "If dream title is longer than 40 characters an error should be returned" {
+      findUserMockWillReturnUser()
+
+      val longTitle = "x".repeat(41)
+      val emptyTitleDreamRequest = DreamRequest(longTitle, "Test", 1000)
+
+      createDream.execute(emptyTitleDreamRequest, 0, 2000)
+        .shouldBeLeft(DreamCreationErrors.TitleTooLong)
+    }
+
+    "If dream description is longer than 200 characters an error should be returned" {
+      findUserMockWillReturnUser()
+
+      val longDescription = "x".repeat(201)
+      val emptyTitleDreamRequest = DreamRequest("Test", longDescription, 1000)
+
+      createDream.execute(emptyTitleDreamRequest, 0, 2000)
+        .shouldBeLeft(DreamCreationErrors.DescriptionTooLong)
+    }
+
+    "If dream dreamt date is placed in the future an error should be returned" {
+      findUserMockWillReturnUser()
+
+      val emptyTitleDreamRequest = DreamRequest("Test", "Description", 2000)
+
+      createDream.execute(emptyTitleDreamRequest, 0, 1000)
+        .shouldBeLeft(DreamCreationErrors.InvalidDate)
+    }
+
+    "If dream creator is not found an error should be returned" {
+      findUserMockWillReturnEmpty()
+
+      val dreamRequest = DreamRequest("Test", "Description", 1000)
+
+      val result = createDream.execute(dreamRequest, 0, 2000)
+      result.shouldNotBeRight()
+      (result as Either.Left<DreamCreationErrors>).a.shouldBeTypeOf<DreamCreationErrors.CreatorNotFound>()
+    }
+
+    "If everything goes okay a dream should be returned" {
+      `when`(mockDao.save(any(DreamEntity::class.java))).thenReturn(DreamEntity())
+      findUserMockWillReturnUser()
+
+      val dreamRequest = DreamRequest("Test", "Description", 1000)
+
+      createDream.execute(dreamRequest, 0, 2000)
+        .shouldBeRight()
+    }
+
+  }
+}

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDreamTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDreamTest.kt
@@ -11,7 +11,6 @@ import com.infusionvlc.somniumserver.users.models.User
 import com.infusionvlc.somniumserver.users.usecases.FindUserById
 import io.kotlintest.assertions.arrow.either.shouldBeLeft
 import io.kotlintest.assertions.arrow.either.shouldBeRight
-import io.kotlintest.assertions.arrow.either.shouldNotBeRight
 import io.kotlintest.matchers.types.shouldBeTypeOf
 import io.kotlintest.specs.StringSpec
 import org.mockito.ArgumentMatchers.any
@@ -87,7 +86,7 @@ class CreateDreamTest : StringSpec() {
       val dreamRequest = DreamRequest("Test", "Description", 1000)
 
       val result = createDream.execute(dreamRequest, 0, 2000)
-      result.shouldNotBeRight()
+      result.shouldBeLeft()
       (result as Either.Left<DreamCreationErrors>).a.shouldBeTypeOf<DreamCreationErrors.CreatorNotFound>()
     }
 

--- a/src/test/kotlin/com/infusionvlc/somniumserver/testFunctions.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/testFunctions.kt
@@ -1,0 +1,5 @@
+package com.infusionvlc.somniumserver
+
+import org.mockito.Mockito
+
+inline fun <reified T> mock(): T = Mockito.mock(T::class.java)


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #1 

### :tophat: What is the goal?

Our goal is creating a basic structure for CRUD operations for Dreams.

### :memo: How is it being implemented?

The most important flow to review in this PR is the creation of new Dreams.

1. At `DreamController` there is a new endpoint listening to `POST /dreams/v1/` which requires a `DreamRequest` as the body of the request (and a `Authentication` which gets injected by the framework)

2. From there, `CreateDream` use case gets called. Its first task is to validate the `DreamRequest` (validation details are explained on the issue). That returns either an error or a Dream in case everything is okay.

3. For saving the Dream in the database we need to map it to `DreamEntity` which is the database domain. And for that we need to retrieve the creator user first. This is done by the `FindUserById` usecase which returns an `Option<User>`. We transform it to `Either` and if the search fails then a left side is returned.

4. Lastly, if everything goes okay, the usecase will return a right side with a Dream. At the controller we just need to handle both sides of the `Either` with `fold` and send responses for every case.

### :boom: How can it be tested?

We won't be testing queries normally. We will cover them with integration tests but there is no need for unit tests.

On the contrary, commands (like creating a dream) usually contain more business logic so they will be tested with unit tests.

- [x] **Creating a dream:**
  - [x] If the request has no title an error should be returned.
  - [x] If the request has no description an error should be returned.
  - [x] If the title is longer than 40 characters an error should be returned.
  - [x] If the body is longer than 200 characters an error should be returned.
  - [x] If the dreamt date is placed in the future an error should be returned.
  - [x] If the creator is not found an error should be returned.
  - [x] If everything is okay a dream should be returned.
 
### 📓 Notes

I've also made some changes to security and stuff. It was for making everything work, there is no need to review that if you don't want to or you don't understand it.

### 💾 : Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.  
