### PR TITLE
Edit dream

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ buildscript {
     kotlinVersion = '1.2.51'
     springBootVersion = '2.0.5.RELEASE'
     kotlintestVersion = "3.1.10"
+    arrowVersion = "0.7.3"
+    swaggerVersion = "2.9.2"
   }
   repositories {
     mavenCentral()
@@ -63,7 +65,7 @@ dependencies {
   implementation("org.jetbrains.kotlin:kotlin-reflect")
   runtimeOnly('org.springframework.boot:spring-boot-devtools')
   runtimeOnly('com.h2database:h2')
-  
+
   testImplementation('org.springframework.boot:spring-boot-starter-test')
   testImplementation('org.springframework.security:spring-security-test')
   testImplementation "io.kotlintest:kotlintest-runner-junit5:$kotlintestVersion"
@@ -71,10 +73,11 @@ dependencies {
 
   ktlint "com.github.shyiko:ktlint:0.20.0"
 
-  implementation "io.arrow-kt:arrow-core:0.7.3"
+  implementation "io.arrow-kt:arrow-core:$arrowVersion"
+  implementation "io.arrow-kt:arrow-syntax:$arrowVersion"
 
-  implementation "io.springfox:springfox-swagger2:2.9.2"
-  implementation "io.springfox:springfox-swagger-ui:2.9.2"
+  implementation "io.springfox:springfox-swagger2:$swaggerVersion"
+  implementation "io.springfox:springfox-swagger-ui:$swaggerVersion"
 }
 
 task ktlint(type: JavaExec, group: "verification") {

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/DreamController.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/DreamController.kt
@@ -52,7 +52,7 @@ class DreamController(
   @PostMapping("/")
   @ApiOperation(value = "Create a new Dream")
   @ApiResponses(
-    ApiResponse(code = 201, response = Dream::class, message = ""),
+    ApiResponse(code = 201, response = Dream::class, message = "Dream is created"),
     ApiResponse(code = 400, message = "Validation error message")
   )
   fun createDream(
@@ -67,6 +67,13 @@ class DreamController(
   }
 
   @PutMapping("/{id}")
+  @ApiOperation(value = "Edit an existing Dream")
+  @ApiResponses(
+    ApiResponse(code = 200, response = Dream::class, message = "Dream is updated"),
+    ApiResponse(code = 403, message = "User is not creator of Dream"),
+    ApiResponse(code = 404, message = "Dream was not found"),
+    ApiResponse(code = 400, message = "Validation error message")
+  )
   fun editDream(
     @RequestBody dreamRequest: DreamRequest,
     @PathVariable id: Long,

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/DreamController.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/DreamController.kt
@@ -2,10 +2,12 @@ package com.infusionvlc.somniumserver.dreams
 
 import com.infusionvlc.somniumserver.dreams.models.Dream
 import com.infusionvlc.somniumserver.dreams.models.DreamCreationErrors
+import com.infusionvlc.somniumserver.dreams.models.DreamEditionErrors
 import com.infusionvlc.somniumserver.dreams.models.DreamRemovalErrors
 import com.infusionvlc.somniumserver.dreams.models.DreamRequest
 import com.infusionvlc.somniumserver.dreams.usecases.CreateDream
 import com.infusionvlc.somniumserver.dreams.usecases.DeleteDream
+import com.infusionvlc.somniumserver.dreams.usecases.EditDream
 import com.infusionvlc.somniumserver.dreams.usecases.GetAllDreams
 import com.infusionvlc.somniumserver.users.security.models.SecurityUser
 import io.swagger.annotations.Api
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -31,6 +34,7 @@ import springfox.documentation.annotations.ApiIgnore
 class DreamController(
   private val getAllDreams: GetAllDreams,
   private val createDream: CreateDream,
+  private val editDream: EditDream,
   private val deleteDream: DeleteDream
 ) {
 
@@ -58,17 +62,27 @@ class DreamController(
     val requestUser = authentication.principal as SecurityUser
     return createDream.execute(dreamRequest, requestUser.id)
       .fold(
+        this::handleDreamCreationError
+      ) { ResponseEntity(it, HttpStatus.CREATED) }
+  }
+
+  @PutMapping("/{id}")
+  fun editDream(
+    @RequestBody dreamRequest: DreamRequest,
+    @PathVariable id: Long,
+    @ApiIgnore authentication: Authentication
+  ): ResponseEntity<*> {
+    val requestUser = authentication.principal as SecurityUser
+    return editDream.execute(id, dreamRequest, requestUser.id)
+      .fold(
         {
-          ResponseEntity(when (it) {
-            is DreamCreationErrors.TitleTooLong -> "Title is too long"
-            is DreamCreationErrors.DescriptionTooLong -> "Description is too long"
-            is DreamCreationErrors.TitleMissing -> "Title is missing"
-            is DreamCreationErrors.DescriptionMissing -> "Description is missing"
-            is DreamCreationErrors.InvalidDate -> "Invalid dreamt date"
-            is DreamCreationErrors.CreatorNotFound -> "User with id ${it.userId} was not found"
-          }, HttpStatus.BAD_REQUEST)
+          when (it) {
+            is DreamEditionErrors.UserIsNotCreator -> handleUserIsNotCreatorOfDreamError()
+            is DreamEditionErrors.DreamNotFound -> handleDreamNotFound(it.id)
+            is DreamCreationErrors -> handleDreamCreationError(it)
+          }
         },
-        { ResponseEntity(it, HttpStatus.CREATED) }
+        { ResponseEntity.ok(it) }
       )
   }
 
@@ -88,13 +102,27 @@ class DreamController(
       .fold(
         {
           when (it) {
-            is DreamRemovalErrors.UserIsNotCreator ->
-              ResponseEntity("User is not creator of dream", HttpStatus.FORBIDDEN)
-            is DreamRemovalErrors.DreamNotFound ->
-              ResponseEntity("Dream with id ${it.id} was not found", HttpStatus.NOT_FOUND)
+            is DreamRemovalErrors.UserIsNotCreator -> handleUserIsNotCreatorOfDreamError()
+            is DreamRemovalErrors.DreamNotFound -> handleDreamNotFound(it.id)
           }
         },
         { ResponseEntity.ok().build<Unit>() }
       )
   }
+
+  private fun handleUserIsNotCreatorOfDreamError(): ResponseEntity<String> =
+    ResponseEntity("User is not creator of dream", HttpStatus.FORBIDDEN)
+
+  private fun handleDreamNotFound(dreamId: Long): ResponseEntity<String> =
+    ResponseEntity("Dream with id $dreamId was not found", HttpStatus.NOT_FOUND)
+
+  private fun handleDreamCreationError(error: DreamCreationErrors): ResponseEntity<String> =
+    ResponseEntity(when (error) {
+      is DreamCreationErrors.TitleTooLong -> "Title is too long"
+      is DreamCreationErrors.DescriptionTooLong -> "Description is too long"
+      is DreamCreationErrors.TitleMissing -> "Title is missing"
+      is DreamCreationErrors.DescriptionMissing -> "Description is missing"
+      is DreamCreationErrors.InvalidDate -> "Invalid dreamt date"
+      is DreamCreationErrors.CreatorNotFound -> "User with id ${error.userId} was not found"
+    }, HttpStatus.BAD_REQUEST)
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamCreationErrors.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamCreationErrors.kt
@@ -1,6 +1,11 @@
 package com.infusionvlc.somniumserver.dreams.models
 
-sealed class DreamCreationErrors {
+sealed class DreamEditionErrors {
+  object UserIsNotCreator : DreamEditionErrors()
+  class DreamNotFound(val id: Long) : DreamEditionErrors()
+}
+
+sealed class DreamCreationErrors : DreamEditionErrors() {
   object TitleTooLong : DreamCreationErrors()
   object DescriptionTooLong : DreamCreationErrors()
   object TitleMissing : DreamCreationErrors()

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDream.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDream.kt
@@ -2,8 +2,6 @@ package com.infusionvlc.somniumserver.dreams.usecases
 
 import arrow.core.Either
 import arrow.core.flatMap
-import arrow.core.left
-import arrow.core.right
 import com.infusionvlc.somniumserver.dreams.models.Dream
 import com.infusionvlc.somniumserver.dreams.models.DreamCreationErrors
 import com.infusionvlc.somniumserver.dreams.models.DreamRequest
@@ -24,20 +22,11 @@ class CreateDream(
     userId: Long,
     currentTime: Long = System.currentTimeMillis()
   ): Either<DreamCreationErrors, Dream> =
-    validate(dreamRequest.toDomain(userId), currentTime)
+    validateDream(dreamRequest.toDomain(userId), currentTime)
       .flatMap { dream ->
         findUserById.execute(userId)
           .toEither { DreamCreationErrors.CreatorNotFound(userId) }
           .map { user -> dao.save(dream.toEntity(user)) }
       }
       .map { it.toDomain() }
-
-  private fun validate(dream: Dream, currentTime: Long): Either<DreamCreationErrors, Dream> = when {
-    dream.title.length > 40 -> DreamCreationErrors.TitleTooLong.left()
-    dream.title.isBlank() -> DreamCreationErrors.TitleMissing.left()
-    dream.description.length > 200 -> DreamCreationErrors.DescriptionTooLong.left()
-    dream.description.isBlank() -> DreamCreationErrors.DescriptionMissing.left()
-    dream.dreamtDate > currentTime -> DreamCreationErrors.InvalidDate.left()
-    else -> dream.right()
-  }
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/DeleteDream.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/DeleteDream.kt
@@ -5,7 +5,6 @@ import arrow.core.flatMap
 import arrow.core.left
 import arrow.core.right
 import com.infusionvlc.somniumserver.base.toOption
-import com.infusionvlc.somniumserver.dreams.models.Dream
 import com.infusionvlc.somniumserver.dreams.models.DreamRemovalErrors
 import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
 import com.infusionvlc.somniumserver.dreams.persistence.toDomain
@@ -27,7 +26,4 @@ class DeleteDream(private val dao: DreamRepository) {
       }
       .map { dao.deleteById(it.id) }
   }
-
-  private fun isUserCreatorOfDream(userId: Long, dream: Dream): Boolean =
-    dream.userId == userId
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/EditDream.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/EditDream.kt
@@ -1,0 +1,53 @@
+package com.infusionvlc.somniumserver.dreams.usecases
+
+import arrow.core.Either
+import arrow.core.flatMap
+import arrow.core.left
+import arrow.core.right
+import com.infusionvlc.somniumserver.base.toOption
+import com.infusionvlc.somniumserver.dreams.models.Dream
+import com.infusionvlc.somniumserver.dreams.models.DreamCreationErrors
+import com.infusionvlc.somniumserver.dreams.models.DreamEditionErrors
+import com.infusionvlc.somniumserver.dreams.models.DreamRequest
+import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
+import com.infusionvlc.somniumserver.dreams.persistence.toDomain
+import com.infusionvlc.somniumserver.dreams.persistence.toEntity
+import com.infusionvlc.somniumserver.users.usecases.FindUserById
+import org.springframework.stereotype.Component
+
+@Component
+class EditDream(
+  private val dao: DreamRepository,
+  private val findUserById: FindUserById
+) {
+  fun execute(
+    dreamId: Long,
+    dreamRequest: DreamRequest,
+    userId: Long,
+    currentTime: Long = System.currentTimeMillis()
+  ): Either<DreamEditionErrors, Dream> = dao.findById(dreamId)
+    .toOption()
+    .map { it.toDomain() }
+    .toEither { DreamEditionErrors.DreamNotFound(dreamId) }
+    .flatMap {
+      if (isUserCreatorOfDream(userId, it))
+        it.right()
+      else
+        DreamEditionErrors.UserIsNotCreator.left()
+    }
+    .map {
+      it.copy(
+        title = dreamRequest.title,
+        description = dreamRequest.description,
+        dreamtDate = dreamRequest.dreamtDate,
+        updateDate = currentTime
+      )
+    }
+    .flatMap { validateDream(it, currentTime) }
+    .flatMap { dream ->
+      findUserById.execute(userId)
+        .toEither { DreamCreationErrors.CreatorNotFound(userId) }
+        .map { dao.save(dream.toEntity(it)) }
+    }
+    .map { it.toDomain() }
+}

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/EditDream.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/EditDream.kt
@@ -1,9 +1,11 @@
 package com.infusionvlc.somniumserver.dreams.usecases
 
 import arrow.core.Either
+import arrow.core.andThen
 import arrow.core.flatMap
 import arrow.core.left
 import arrow.core.right
+import arrow.syntax.function.andThen
 import com.infusionvlc.somniumserver.base.toOption
 import com.infusionvlc.somniumserver.dreams.models.Dream
 import com.infusionvlc.somniumserver.dreams.models.DreamCreationErrors
@@ -25,29 +27,52 @@ class EditDream(
     dreamRequest: DreamRequest,
     userId: Long,
     currentTime: Long = System.currentTimeMillis()
-  ): Either<DreamEditionErrors, Dream> = dao.findById(dreamId)
-    .toOption()
-    .map { it.toDomain() }
-    .toEither { DreamEditionErrors.DreamNotFound(dreamId) }
-    .flatMap {
+  ): Either<DreamEditionErrors, Dream> = (
+    retrieveDreamFromPersistence(dao, dreamId) andThen
+      checkUserIsCreatorOfDream(userId) andThen
+      updateDream(dreamRequest, currentTime) andThen
+      validate(currentTime) andThen
+      storeDream(userId)
+    )()
+
+  private fun retrieveDreamFromPersistence(dao: DreamRepository, dreamId: Long) = {
+    dao.findById(dreamId)
+      .toOption()
+      .map { it.toDomain() }
+      .toEither { DreamEditionErrors.DreamNotFound(dreamId) }
+  }
+
+  private fun checkUserIsCreatorOfDream(userId: Long) = { either: Either<DreamEditionErrors, Dream> ->
+    either.flatMap {
       if (isUserCreatorOfDream(userId, it))
         it.right()
       else
         DreamEditionErrors.UserIsNotCreator.left()
     }
-    .map {
-      it.copy(
-        title = dreamRequest.title,
-        description = dreamRequest.description,
-        dreamtDate = dreamRequest.dreamtDate,
-        updateDate = currentTime
-      )
+  }
+
+  private fun updateDream(dreamRequest: DreamRequest, currentTime: Long) =
+    { either: Either<DreamEditionErrors, Dream> ->
+      either.map {
+        it.copy(
+          title = dreamRequest.title,
+          description = dreamRequest.description,
+          dreamtDate = dreamRequest.dreamtDate,
+          updateDate = currentTime
+        )
+      }
     }
-    .flatMap { validateDream(it, currentTime) }
-    .flatMap { dream ->
+
+  private fun validate(currentTime: Long) = { either: Either<DreamEditionErrors, Dream> ->
+    either.flatMap { validateDream(it, currentTime) }
+  }
+
+  private fun storeDream(userId: Long) = { either: Either<DreamEditionErrors, Dream> ->
+    either.flatMap { dream ->
       findUserById.execute(userId)
         .toEither { DreamCreationErrors.CreatorNotFound(userId) }
         .map { dao.save(dream.toEntity(it)) }
+        .map { it.toDomain() }
     }
-    .map { it.toDomain() }
+  }
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/logic.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/logic.kt
@@ -1,0 +1,19 @@
+package com.infusionvlc.somniumserver.dreams.usecases
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.infusionvlc.somniumserver.dreams.models.Dream
+import com.infusionvlc.somniumserver.dreams.models.DreamCreationErrors
+
+fun isUserCreatorOfDream(userId: Long, dream: Dream): Boolean =
+  dream.userId == userId
+
+fun validateDream(dream: Dream, currentTime: Long): Either<DreamCreationErrors, Dream> = when {
+  dream.title.length > 40 -> DreamCreationErrors.TitleTooLong.left()
+  dream.title.isBlank() -> DreamCreationErrors.TitleMissing.left()
+  dream.description.length > 200 -> DreamCreationErrors.DescriptionTooLong.left()
+  dream.description.isBlank() -> DreamCreationErrors.DescriptionMissing.left()
+  dream.dreamtDate > currentTime -> DreamCreationErrors.InvalidDate.left()
+  else -> dream.right()
+}

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/EditDreamTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/EditDreamTest.kt
@@ -38,7 +38,6 @@ class EditDreamTest : StringSpec() {
       result.shouldBeLeft()
       (result as Either.Left<DreamEditionErrors>).a.shouldBeTypeOf<DreamEditionErrors.DreamNotFound>()
     }
-
   }
 
   private fun mockWillFindDream() {
@@ -48,5 +47,4 @@ class EditDreamTest : StringSpec() {
   private fun mockWontFindDream() {
     `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Optional.empty())
   }
-
 }

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/EditDreamTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/EditDreamTest.kt
@@ -1,0 +1,52 @@
+package com.infusionvlc.somniumserver.dreams.usecases
+
+import arrow.core.Either
+import com.infusionvlc.somniumserver.dreams.models.DreamEditionErrors
+import com.infusionvlc.somniumserver.dreams.models.DreamRequest
+import com.infusionvlc.somniumserver.dreams.persistence.DreamEntity
+import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
+import com.infusionvlc.somniumserver.mock
+import com.infusionvlc.somniumserver.users.usecases.FindUserById
+import io.kotlintest.assertions.arrow.either.shouldBeLeft
+import io.kotlintest.matchers.types.shouldBeTypeOf
+import io.kotlintest.specs.StringSpec
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.`when`
+import java.util.Optional
+
+class EditDreamTest : StringSpec() {
+
+  private val mockDao = mock<DreamRepository>()
+  private val mockFindUser = mock<FindUserById>()
+  private val editDream = EditDream(mockDao, mockFindUser)
+
+  init {
+
+    "If user is not creator of dream an error should be returned" {
+      mockWillFindDream()
+
+      val result = editDream.execute(1, DreamRequest(), 1, 1000)
+
+      result.shouldBeLeft(DreamEditionErrors.UserIsNotCreator)
+    }
+
+    "If dream is not found an error should be returned" {
+      mockWontFindDream()
+
+      val result = editDream.execute(1, DreamRequest(), 1, 1000)
+
+      result.shouldBeLeft()
+      (result as Either.Left<DreamEditionErrors>).a.shouldBeTypeOf<DreamEditionErrors.DreamNotFound>()
+    }
+
+  }
+
+  private fun mockWillFindDream() {
+    `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Optional.of(DreamEntity()))
+  }
+
+  private fun mockWontFindDream() {
+    `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Optional.empty())
+  }
+
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #3 
* **Related pull-requests:** #17 

### :tophat: What is the goal?

As a creator of a Dream I want to be able to edit that dream.

### :memo: How is it being implemented?

I've created a new use case for editing dreams which is a lot like `CreateDream`. I've done several refactors for reusing existing code and favouring a functional fashion 😎 🤓 

### :boom: How can it be tested?

Since updating is almost creating there are only two corner cases to test:

* User is not creator of dream
* Dream is not found

- [x] **Edit a Dream:**
  - [x] Create a Dream
  - [x] Update it (check #2 for validation corner cases)
  - [x] Try to update a Dream from another user
  - [x] Try to update a non existing Dream
 
### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.  
