### PR TITLE
Refactoring persitence layer so domain layer only knows about domain

### DIFF
--- a/src/main/kotlin/com/infusionvlc/somniumserver/base/TryExtensions.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/base/TryExtensions.kt
@@ -1,0 +1,7 @@
+package com.infusionvlc.somniumserver.base
+
+import arrow.core.Either
+import arrow.core.Try
+
+fun <L, R> Try<R>.toEither(f: (Throwable) -> L): Either<L, R> =
+  toEither().mapLeft(f)

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/Dream.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/Dream.kt
@@ -1,12 +1,12 @@
 package com.infusionvlc.somniumserver.dreams.models
 
 data class Dream(
-  val id: Long,
-  val title: String,
-  val description: String,
-  val userId: Long,
-  val public: Boolean,
-  val creationDate: Long,
-  val updateDate: Long,
-  val dreamtDate: Long
+  val id: Long = 0,
+  val title: String = "",
+  val description: String = "",
+  val userId: Long = 0,
+  val public: Boolean = true,
+  val creationDate: Long = 0,
+  val updateDate: Long = 0,
+  val dreamtDate: Long = 0
 )

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/Dream.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/Dream.kt
@@ -1,12 +1,12 @@
 package com.infusionvlc.somniumserver.dreams.models
 
 data class Dream(
-  val id: Long = 0,
-  val title: String = "",
-  val description: String = "",
-  val userId: Long = 0,
-  val public: Boolean = true,
-  val creationDate: Long = 0,
-  val updateDate: Long = 0,
-  val dreamtDate: Long = 0
+  val id: Long,
+  val title: String,
+  val description: String,
+  val userId: Long,
+  val public: Boolean,
+  val creationDate: Long,
+  val updateDate: Long,
+  val dreamtDate: Long
 )

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamCreationErrors.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamCreationErrors.kt
@@ -3,6 +3,7 @@ package com.infusionvlc.somniumserver.dreams.models
 sealed class DreamEditionErrors {
   object UserIsNotCreator : DreamEditionErrors()
   class DreamNotFound(val id: Long) : DreamEditionErrors()
+  object PersistenceError : DreamEditionErrors()
 }
 
 sealed class DreamCreationErrors : DreamEditionErrors() {
@@ -12,4 +13,5 @@ sealed class DreamCreationErrors : DreamEditionErrors() {
   object DescriptionMissing : DreamCreationErrors()
   object InvalidDate : DreamCreationErrors()
   class CreatorNotFound(val userId: Long) : DreamCreationErrors()
+  object PersistenceError : DreamCreationErrors()
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamRemovalErrors.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamRemovalErrors.kt
@@ -3,4 +3,5 @@ package com.infusionvlc.somniumserver.dreams.models
 sealed class DreamRemovalErrors {
   class DreamNotFound(val id: Long) : DreamRemovalErrors()
   object UserIsNotCreator : DreamRemovalErrors()
+  object PersistenceError : DreamRemovalErrors()
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/persistence/DreamDAO.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/persistence/DreamDAO.kt
@@ -1,0 +1,38 @@
+package com.infusionvlc.somniumserver.dreams.persistence
+
+import arrow.core.Option
+import arrow.core.Try
+import com.infusionvlc.somniumserver.base.toOption
+import com.infusionvlc.somniumserver.dreams.models.Dream
+import com.infusionvlc.somniumserver.users.models.User
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Component
+
+@Component
+class DreamDAO(private val localDatasource: DreamLocalDatasource) {
+
+  fun findAllVisibleByUser(userId: Long, page: Int, pageSize: Int): List<Dream> = localDatasource
+    .findAllVisibleByUser(userId, PageRequest.of(page, pageSize))
+    .toList()
+    .map(DreamEntity::toDomain)
+
+  fun findById(dreamId: Long): Option<Dream> = localDatasource
+    .findById(dreamId)
+    .toOption()
+    .map(DreamEntity::toDomain)
+
+  fun searchDream(title: String, page: Int, pageSize: Int): List<Dream> = localDatasource
+    .findByTitleContainingIgnoreCase(title, PageRequest.of(page, pageSize))
+    .toList()
+    .map(DreamEntity::toDomain)
+
+  fun saveDream(dream: Dream, user: User): Try<Dream> = Try {
+    localDatasource
+      .save(dream.toEntity(user))
+      .toDomain()
+  }
+
+  fun deleteDream(dreamId: Long): Try<Unit> = Try {
+    localDatasource.deleteById(dreamId)
+  }
+}

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/persistence/DreamLocalDatasource.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/persistence/DreamLocalDatasource.kt
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.PagingAndSortingRepository
 
-interface DreamRepository : PagingAndSortingRepository<DreamEntity, Long> {
+interface DreamLocalDatasource : PagingAndSortingRepository<DreamEntity, Long> {
   @Query("Select d from DreamEntity d where d.public = true or (d.public = false and d.user.id = :userId)")
   fun findAllVisibleByUser(userId: Long, pageable: Pageable): Page<DreamEntity>
 

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDream.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDream.kt
@@ -2,31 +2,30 @@ package com.infusionvlc.somniumserver.dreams.usecases
 
 import arrow.core.Either
 import arrow.core.flatMap
+import com.infusionvlc.somniumserver.base.toEither
 import com.infusionvlc.somniumserver.dreams.models.Dream
 import com.infusionvlc.somniumserver.dreams.models.DreamCreationErrors
-import com.infusionvlc.somniumserver.dreams.models.DreamRequest
-import com.infusionvlc.somniumserver.dreams.models.toDomain
-import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
-import com.infusionvlc.somniumserver.dreams.persistence.toDomain
-import com.infusionvlc.somniumserver.dreams.persistence.toEntity
+import com.infusionvlc.somniumserver.dreams.persistence.DreamDAO
 import com.infusionvlc.somniumserver.users.usecases.FindUserById
 import org.springframework.stereotype.Component
 
 @Component
 class CreateDream(
-  private val dao: DreamRepository,
+  private val dao: DreamDAO,
   private val findUserById: FindUserById
 ) {
   fun execute(
-    dreamRequest: DreamRequest,
+    dream: Dream,
     userId: Long,
     currentTime: Long = System.currentTimeMillis()
   ): Either<DreamCreationErrors, Dream> =
-    validateDream(dreamRequest.toDomain(userId), currentTime)
+    validateDream(dream, currentTime)
       .flatMap { dream ->
         findUserById.execute(userId)
           .toEither { DreamCreationErrors.CreatorNotFound(userId) }
-          .map { user -> dao.save(dream.toEntity(user)) }
+          .flatMap { user ->
+            dao.saveDream(dream, user)
+              .toEither { DreamCreationErrors.PersistenceError }
+          }
       }
-      .map { it.toDomain() }
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/EditDream.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/EditDream.kt
@@ -1,25 +1,22 @@
 package com.infusionvlc.somniumserver.dreams.usecases
 
 import arrow.core.Either
-import arrow.core.andThen
 import arrow.core.flatMap
 import arrow.core.left
 import arrow.core.right
 import arrow.syntax.function.andThen
-import com.infusionvlc.somniumserver.base.toOption
+import com.infusionvlc.somniumserver.base.toEither
 import com.infusionvlc.somniumserver.dreams.models.Dream
 import com.infusionvlc.somniumserver.dreams.models.DreamCreationErrors
 import com.infusionvlc.somniumserver.dreams.models.DreamEditionErrors
 import com.infusionvlc.somniumserver.dreams.models.DreamRequest
-import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
-import com.infusionvlc.somniumserver.dreams.persistence.toDomain
-import com.infusionvlc.somniumserver.dreams.persistence.toEntity
+import com.infusionvlc.somniumserver.dreams.persistence.DreamDAO
 import com.infusionvlc.somniumserver.users.usecases.FindUserById
 import org.springframework.stereotype.Component
 
 @Component
 class EditDream(
-  private val dao: DreamRepository,
+  private val dao: DreamDAO,
   private val findUserById: FindUserById
 ) {
   fun execute(
@@ -35,10 +32,8 @@ class EditDream(
       storeDream(userId)
     )()
 
-  private fun retrieveDreamFromPersistence(dao: DreamRepository, dreamId: Long) = {
+  private fun retrieveDreamFromPersistence(dao: DreamDAO, dreamId: Long) = {
     dao.findById(dreamId)
-      .toOption()
-      .map { it.toDomain() }
       .toEither { DreamEditionErrors.DreamNotFound(dreamId) }
   }
 
@@ -71,8 +66,8 @@ class EditDream(
     either.flatMap { dream ->
       findUserById.execute(userId)
         .toEither { DreamCreationErrors.CreatorNotFound(userId) }
-        .map { dao.save(dream.toEntity(it)) }
-        .map { it.toDomain() }
+        .map { dao.saveDream(dream, it) }
+        .flatMap { it.toEither { DreamCreationErrors.PersistenceError } }
     }
   }
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/GetAllDreams.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/GetAllDreams.kt
@@ -1,17 +1,13 @@
 package com.infusionvlc.somniumserver.dreams.usecases
 
 import com.infusionvlc.somniumserver.dreams.models.Dream
-import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
-import com.infusionvlc.somniumserver.dreams.persistence.toDomain
-import org.springframework.data.domain.PageRequest
+import com.infusionvlc.somniumserver.dreams.persistence.DreamDAO
 import org.springframework.stereotype.Component
 
 @Component
 class GetAllDreams(
-  private val dao: DreamRepository
+  private val dao: DreamDAO
 ) {
   fun execute(userId: Long, page: Int, pageSize: Int): List<Dream> =
-    dao.findAllVisibleByUser(userId, PageRequest.of(page, pageSize))
-      .map { it.toDomain() }
-      .toList()
+    dao.findAllVisibleByUser(userId, page, pageSize)
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/GetDreamById.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/GetDreamById.kt
@@ -4,17 +4,14 @@ import arrow.core.Either
 import arrow.core.flatMap
 import arrow.core.left
 import arrow.core.right
-import com.infusionvlc.somniumserver.base.toOption
 import com.infusionvlc.somniumserver.dreams.models.Dream
 import com.infusionvlc.somniumserver.dreams.models.DreamDetailErrors
-import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
-import com.infusionvlc.somniumserver.dreams.persistence.toDomain
+import com.infusionvlc.somniumserver.dreams.persistence.DreamDAO
 import org.springframework.stereotype.Component
 
 @Component
-class GetDreamById(private val dao: DreamRepository) {
-  fun execute(dreamId: Long, userId: Long): Either<DreamDetailErrors, Dream> = dao.findById(dreamId).toOption()
-    .map { it.toDomain() }
+class GetDreamById(private val dao: DreamDAO) {
+  fun execute(dreamId: Long, userId: Long): Either<DreamDetailErrors, Dream> = dao.findById(dreamId)
     .toEither { DreamDetailErrors.DreamNotFound(dreamId) }
     .flatMap {
       if (!it.public && !isUserCreatorOfDream(userId, it)) DreamDetailErrors.DreamIsNotPublic.left()

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/SearchDream.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/usecases/SearchDream.kt
@@ -1,17 +1,13 @@
 package com.infusionvlc.somniumserver.dreams.usecases
 
 import com.infusionvlc.somniumserver.dreams.models.Dream
-import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
-import com.infusionvlc.somniumserver.dreams.persistence.toDomain
-import org.springframework.data.domain.PageRequest
+import com.infusionvlc.somniumserver.dreams.persistence.DreamDAO
 import org.springframework.stereotype.Component
 
 @Component
 class SearchDream(
-  private val dao: DreamRepository
+  private val dao: DreamDAO
 ) {
   fun execute(title: String, page: Int, pageSize: Int): List<Dream> =
-    dao.findByTitleContainingIgnoreCase(title, PageRequest.of(page, pageSize))
-      .map { it.toDomain() }
-      .toList()
+    dao.searchDream(title, page, pageSize)
 }

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/dreamGenerators.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/dreamGenerators.kt
@@ -1,0 +1,14 @@
+package com.infusionvlc.somniumserver.dreams
+
+import com.infusionvlc.somniumserver.dreams.models.Dream
+
+fun fakeDream() = Dream(
+  id = 1,
+  title = "Test",
+  description = "Test",
+  userId = 0,
+  public = true,
+  creationDate = 1234567890,
+  updateDate = 1234567890,
+  dreamtDate = 1234567890
+)

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/integration/DreamDetailsIntegrationTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/integration/DreamDetailsIntegrationTest.kt
@@ -2,7 +2,7 @@ package com.infusionvlc.somniumserver.dreams.integration
 
 import com.infusionvlc.somniumserver.dreams.models.Dream
 import com.infusionvlc.somniumserver.dreams.persistence.DreamEntity
-import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
+import com.infusionvlc.somniumserver.dreams.persistence.DreamLocalDatasource
 import com.infusionvlc.somniumserver.dreams.persistence.toDomain
 import com.infusionvlc.somniumserver.getForEntityAuthorized
 import com.infusionvlc.somniumserver.users.persistence.UserEntity
@@ -33,7 +33,7 @@ class DreamDetailsIntegrationTest : WordSpec() {
   lateinit var userDao: UserRepository
 
   @Autowired
-  lateinit var dreamDao: DreamRepository
+  lateinit var dreamDao: DreamLocalDatasource
 
   private lateinit var TONI_PUBLIC_DREAM: Dream
   private lateinit var TONI_PRIVATE_DREAM: Dream

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/integration/SearchDreamIntegrationTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/integration/SearchDreamIntegrationTest.kt
@@ -2,7 +2,7 @@ package com.infusionvlc.somniumserver.dreams.integration
 
 import com.infusionvlc.somniumserver.dreams.models.Dream
 import com.infusionvlc.somniumserver.dreams.persistence.DreamEntity
-import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
+import com.infusionvlc.somniumserver.dreams.persistence.DreamLocalDatasource
 import com.infusionvlc.somniumserver.dreams.persistence.toDomain
 import com.infusionvlc.somniumserver.getForEntityAuthorized
 import com.infusionvlc.somniumserver.users.persistence.UserEntity
@@ -39,7 +39,7 @@ class SearchDreamIntegrationTest : WordSpec() {
   var port: Int = 0
 
   @Autowired
-  lateinit var dreamDao: DreamRepository
+  lateinit var dreamDao: DreamLocalDatasource
   @Autowired
   lateinit var userDao: UserRepository
 

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDreamTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDreamTest.kt
@@ -4,7 +4,7 @@ import arrow.core.Either
 import arrow.core.Option
 import arrow.core.Try
 import com.infusionvlc.somniumserver.AnyMocker
-import com.infusionvlc.somniumserver.dreams.models.Dream
+import com.infusionvlc.somniumserver.dreams.fakeDream
 import com.infusionvlc.somniumserver.dreams.models.DreamCreationErrors
 import com.infusionvlc.somniumserver.dreams.models.DreamRequest
 import com.infusionvlc.somniumserver.dreams.models.toDomain
@@ -99,7 +99,7 @@ class CreateDreamTest : StringSpec(), AnyMocker {
     }
 
     "If everything goes okay a dream should be returned" {
-      `when`(mockDao.saveDream(any(), any())).thenReturn(Try.just(Dream()))
+      `when`(mockDao.saveDream(any(), any())).thenReturn(Try.just(fakeDream()))
       findUserMockWillReturnUser()
 
       val dreamRequest = DreamRequest("Test", "Description", 1000)

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDreamTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/CreateDreamTest.kt
@@ -2,10 +2,13 @@ package com.infusionvlc.somniumserver.dreams.usecases
 
 import arrow.core.Either
 import arrow.core.Option
+import arrow.core.Try
+import com.infusionvlc.somniumserver.AnyMocker
+import com.infusionvlc.somniumserver.dreams.models.Dream
 import com.infusionvlc.somniumserver.dreams.models.DreamCreationErrors
 import com.infusionvlc.somniumserver.dreams.models.DreamRequest
-import com.infusionvlc.somniumserver.dreams.persistence.DreamEntity
-import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
+import com.infusionvlc.somniumserver.dreams.models.toDomain
+import com.infusionvlc.somniumserver.dreams.persistence.DreamDAO
 import com.infusionvlc.somniumserver.mock
 import com.infusionvlc.somniumserver.users.models.User
 import com.infusionvlc.somniumserver.users.usecases.FindUserById
@@ -13,13 +16,12 @@ import io.kotlintest.assertions.arrow.either.shouldBeLeft
 import io.kotlintest.assertions.arrow.either.shouldBeRight
 import io.kotlintest.matchers.types.shouldBeTypeOf
 import io.kotlintest.specs.StringSpec
-import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.`when`
 
-class CreateDreamTest : StringSpec() {
+class CreateDreamTest : StringSpec(), AnyMocker {
 
-  private val mockDao = mock<DreamRepository>()
+  private val mockDao = mock<DreamDAO>()
   private val mockFindUser = mock<FindUserById>()
   private val createDream = CreateDream(mockDao, mockFindUser)
 
@@ -37,6 +39,7 @@ class CreateDreamTest : StringSpec() {
       findUserMockWillReturnUser()
 
       val emptyTitleDreamRequest = DreamRequest(description = "Test", dreamtDate = 1000)
+        .toDomain(100)
 
       createDream.execute(emptyTitleDreamRequest, 2000)
         .shouldBeLeft(DreamCreationErrors.TitleMissing)
@@ -46,6 +49,7 @@ class CreateDreamTest : StringSpec() {
       findUserMockWillReturnUser()
 
       val emptyDescriptionDreamRequest = DreamRequest(title = "Test", dreamtDate = 1000)
+        .toDomain(100)
 
       createDream.execute(emptyDescriptionDreamRequest, 0, 2000)
         .shouldBeLeft(DreamCreationErrors.DescriptionMissing)
@@ -56,6 +60,7 @@ class CreateDreamTest : StringSpec() {
 
       val longTitle = "x".repeat(41)
       val longTitleDreamRequest = DreamRequest(longTitle, "Test", 1000)
+        .toDomain(100)
 
       createDream.execute(longTitleDreamRequest, 0, 2000)
         .shouldBeLeft(DreamCreationErrors.TitleTooLong)
@@ -66,6 +71,7 @@ class CreateDreamTest : StringSpec() {
 
       val longDescription = "x".repeat(201)
       val longDescriptionDreamRequest = DreamRequest("Test", longDescription, 1000)
+        .toDomain(100)
 
       createDream.execute(longDescriptionDreamRequest, 0, 2000)
         .shouldBeLeft(DreamCreationErrors.DescriptionTooLong)
@@ -75,6 +81,7 @@ class CreateDreamTest : StringSpec() {
       findUserMockWillReturnUser()
 
       val futureDateDreamRequest = DreamRequest("Test", "Description", 2000)
+        .toDomain(100)
 
       createDream.execute(futureDateDreamRequest, 0, 1000)
         .shouldBeLeft(DreamCreationErrors.InvalidDate)
@@ -84,6 +91,7 @@ class CreateDreamTest : StringSpec() {
       findUserMockWillReturnEmpty()
 
       val dreamRequest = DreamRequest("Test", "Description", 1000)
+        .toDomain(100)
 
       val result = createDream.execute(dreamRequest, 0, 2000)
       result.shouldBeLeft()
@@ -91,10 +99,11 @@ class CreateDreamTest : StringSpec() {
     }
 
     "If everything goes okay a dream should be returned" {
-      `when`(mockDao.save(any(DreamEntity::class.java))).thenReturn(DreamEntity())
+      `when`(mockDao.saveDream(any(), any())).thenReturn(Try.just(Dream()))
       findUserMockWillReturnUser()
 
       val dreamRequest = DreamRequest("Test", "Description", 1000)
+        .toDomain(100)
 
       createDream.execute(dreamRequest, 0, 2000)
         .shouldBeRight()

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/DeleteDreamTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/DeleteDreamTest.kt
@@ -1,21 +1,28 @@
 package com.infusionvlc.somniumserver.dreams.usecases
 
 import arrow.core.Either
+import arrow.core.Option
+import arrow.core.Try
+import com.infusionvlc.somniumserver.dreams.models.Dream
 import com.infusionvlc.somniumserver.dreams.models.DreamRemovalErrors
-import com.infusionvlc.somniumserver.dreams.persistence.DreamEntity
-import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
+import com.infusionvlc.somniumserver.dreams.persistence.DreamDAO
 import com.infusionvlc.somniumserver.mock
+import io.kotlintest.Description
 import io.kotlintest.assertions.arrow.either.shouldBeLeft
 import io.kotlintest.assertions.arrow.either.shouldBeRight
 import io.kotlintest.matchers.types.shouldBeTypeOf
 import io.kotlintest.specs.StringSpec
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.`when`
-import java.util.Optional
 
 class DeleteDreamTest : StringSpec() {
-  private val mockDao = mock<DreamRepository>()
+  private val mockDao = mock<DreamDAO>()
   private val deleteDream = DeleteDream(mockDao)
+
+  override fun beforeTest(description: Description) {
+    super.beforeTest(description)
+    mockDaoWillSuccessAtDeletion()
+  }
 
   init {
 
@@ -46,10 +53,14 @@ class DeleteDreamTest : StringSpec() {
   }
 
   private fun mockDaoWontFindDream() {
-    `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Optional.empty())
+    `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Option.empty())
   }
 
   private fun mockDaoWillFindDream() {
-    `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Optional.of(DreamEntity()))
+    `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Option.just(Dream()))
+  }
+
+  private fun mockDaoWillSuccessAtDeletion() {
+    `when`(mockDao.deleteDream(ArgumentMatchers.anyLong())).thenReturn(Try.just(Unit))
   }
 }

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/DeleteDreamTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/DeleteDreamTest.kt
@@ -3,7 +3,7 @@ package com.infusionvlc.somniumserver.dreams.usecases
 import arrow.core.Either
 import arrow.core.Option
 import arrow.core.Try
-import com.infusionvlc.somniumserver.dreams.models.Dream
+import com.infusionvlc.somniumserver.dreams.fakeDream
 import com.infusionvlc.somniumserver.dreams.models.DreamRemovalErrors
 import com.infusionvlc.somniumserver.dreams.persistence.DreamDAO
 import com.infusionvlc.somniumserver.mock
@@ -57,7 +57,7 @@ class DeleteDreamTest : StringSpec() {
   }
 
   private fun mockDaoWillFindDream() {
-    `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Option.just(Dream()))
+    `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Option.just(fakeDream()))
   }
 
   private fun mockDaoWillSuccessAtDeletion() {

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/EditDreamTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/EditDreamTest.kt
@@ -2,7 +2,7 @@ package com.infusionvlc.somniumserver.dreams.usecases
 
 import arrow.core.Either
 import arrow.core.Option
-import com.infusionvlc.somniumserver.dreams.models.Dream
+import com.infusionvlc.somniumserver.dreams.fakeDream
 import com.infusionvlc.somniumserver.dreams.models.DreamEditionErrors
 import com.infusionvlc.somniumserver.dreams.models.DreamRequest
 import com.infusionvlc.somniumserver.dreams.persistence.DreamDAO
@@ -41,7 +41,7 @@ class EditDreamTest : StringSpec() {
   }
 
   private fun mockWillFindDream() {
-    `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Option.just(Dream()))
+    `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Option.just(fakeDream()))
   }
 
   private fun mockWontFindDream() {

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/EditDreamTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/EditDreamTest.kt
@@ -1,10 +1,11 @@
 package com.infusionvlc.somniumserver.dreams.usecases
 
 import arrow.core.Either
+import arrow.core.Option
+import com.infusionvlc.somniumserver.dreams.models.Dream
 import com.infusionvlc.somniumserver.dreams.models.DreamEditionErrors
 import com.infusionvlc.somniumserver.dreams.models.DreamRequest
-import com.infusionvlc.somniumserver.dreams.persistence.DreamEntity
-import com.infusionvlc.somniumserver.dreams.persistence.DreamRepository
+import com.infusionvlc.somniumserver.dreams.persistence.DreamDAO
 import com.infusionvlc.somniumserver.mock
 import com.infusionvlc.somniumserver.users.usecases.FindUserById
 import io.kotlintest.assertions.arrow.either.shouldBeLeft
@@ -12,11 +13,10 @@ import io.kotlintest.matchers.types.shouldBeTypeOf
 import io.kotlintest.specs.StringSpec
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.`when`
-import java.util.Optional
 
 class EditDreamTest : StringSpec() {
 
-  private val mockDao = mock<DreamRepository>()
+  private val mockDao = mock<DreamDAO>()
   private val mockFindUser = mock<FindUserById>()
   private val editDream = EditDream(mockDao, mockFindUser)
 
@@ -41,10 +41,10 @@ class EditDreamTest : StringSpec() {
   }
 
   private fun mockWillFindDream() {
-    `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Optional.of(DreamEntity()))
+    `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Option.just(Dream()))
   }
 
   private fun mockWontFindDream() {
-    `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Optional.empty())
+    `when`(mockDao.findById(ArgumentMatchers.anyLong())).thenReturn(Option.empty())
   }
 }

--- a/src/test/kotlin/com/infusionvlc/somniumserver/testFunctions.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/testFunctions.kt
@@ -7,6 +7,15 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.web.client.RestTemplate
 
+interface AnyMocker {
+  fun <T> any(): T {
+    Mockito.any<T>()
+    return uninitialized()
+  }
+
+  fun <T> uninitialized(): T = null as T
+}
+
 inline fun <reified T> mock(): T = Mockito.mock(T::class.java)
 
 inline fun <reified T> RestTemplate.getForEntityAuthorized(url: String): ResponseEntity<T> {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** None
* **Related pull-requests:** None

### :tophat: What is the goal?

Refactor the persistence layer so domain layer only knows about the domain layer. The only entrypoint are DAO objects which decouple us from the persistence implementation.

### :memo: How is it being implemented?

We are creating a new DAO object which acts as a facade for the persistence layer and performs all mappings required between these layers. This way our domain layer (usecases) only know about the business logic domain.

### :boom: How can it be tested?

There are no new things. I've been able to refactor this knowing everything works fine thanks to the already implemented tests. **This is why you need tests in your codebase** along many other advantages.
 
### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.  
