### PR TITLE
Search Tags

### DIFF
--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/DreamController.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/DreamController.kt
@@ -186,6 +186,7 @@ class DreamController(
       is TagCreationErrors.TitleMissing -> "Tag title is missing"
       is TagCreationErrors.TitleTooLong -> "Tag title cannot be longer than 20 characters"
       is TagCreationErrors.CreationError -> "Something failed while creating tag"
+      is TagCreationErrors.PersistenceError -> persistenceErrorString
     }, HttpStatus.BAD_REQUEST)
 
   private val persistenceErrorString = "Database operation failed"

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamCreationErrors.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamCreationErrors.kt
@@ -20,5 +20,5 @@ sealed class TagCreationErrors : DreamCreationErrors() {
   object TitleMissing : TagCreationErrors()
   object TitleTooLong : TagCreationErrors()
   object CreationError : TagCreationErrors()
-  object PersistenceError: TagCreationErrors()
+  object PersistenceError : TagCreationErrors()
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamCreationErrors.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/dreams/models/DreamCreationErrors.kt
@@ -20,4 +20,5 @@ sealed class TagCreationErrors : DreamCreationErrors() {
   object TitleMissing : TagCreationErrors()
   object TitleTooLong : TagCreationErrors()
   object CreationError : TagCreationErrors()
+  object PersistenceError: TagCreationErrors()
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/tags/TagController.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/tags/TagController.kt
@@ -1,0 +1,33 @@
+package com.infusionvlc.somniumserver.tags
+
+import com.infusionvlc.somniumserver.tags.models.Tag
+import com.infusionvlc.somniumserver.tags.usecases.SearchTag
+import io.swagger.annotations.Api
+import io.swagger.annotations.ApiOperation
+import io.swagger.annotations.ApiResponse
+import io.swagger.annotations.ApiResponses
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/tags/v1")
+@Api(value = "Tags", description = "Endpoints for Tags resources")
+class TagController(
+  private val searchTag: SearchTag
+) {
+
+  @GetMapping("/search")
+  @ApiOperation(value = "Search tag by title")
+  @ApiResponses(
+    ApiResponse(code = 200, response = Tag::class, responseContainer = "List", message = "Tags result")
+  )
+  fun searchTag(
+    @RequestParam("title") title: String,
+    @RequestParam("page") page: Int,
+    @RequestParam("page_size") pageSize: Int
+  ): ResponseEntity<List<Tag>> =
+    ResponseEntity.ok(searchTag.execute(title, page, pageSize))
+}

--- a/src/main/kotlin/com/infusionvlc/somniumserver/tags/models/TagCreationErrors.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/tags/models/TagCreationErrors.kt
@@ -4,4 +4,5 @@ sealed class TagCreationErrors {
   object TitleMissing : TagCreationErrors()
   object TitleTooLong : TagCreationErrors()
   object CreationError : TagCreationErrors()
+  object PersistenceError: TagCreationErrors()
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/tags/models/TagCreationErrors.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/tags/models/TagCreationErrors.kt
@@ -4,5 +4,5 @@ sealed class TagCreationErrors {
   object TitleMissing : TagCreationErrors()
   object TitleTooLong : TagCreationErrors()
   object CreationError : TagCreationErrors()
-  object PersistenceError: TagCreationErrors()
+  object PersistenceError : TagCreationErrors()
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/tags/persistence/TagDAO.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/tags/persistence/TagDAO.kt
@@ -1,0 +1,27 @@
+package com.infusionvlc.somniumserver.tags.persistence
+
+import arrow.core.Option
+import arrow.core.Try
+import arrow.core.toOption
+import com.infusionvlc.somniumserver.tags.models.Tag
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Component
+
+@Component
+class TagDAO(private val localDatasource: TagLocalDatasource) {
+
+  fun findByTitle(title: String): Option<Tag> = Option
+    .fromNullable(localDatasource.findByTitle(title).toOption().orNull())
+    .map(TagEntity::toDomain)
+
+  fun searchTag(title: String, page: Int, pageSize: Int): List<Tag> =
+    localDatasource.findByTitleContainingIgnoreCase(title, PageRequest.of(page, pageSize))
+      .toList()
+      .map(TagEntity::toDomain)
+
+  fun save(tag: Tag): Try<Tag> = Try {
+    localDatasource
+      .save(tag.toEntity())
+      .toDomain()
+  }
+}

--- a/src/main/kotlin/com/infusionvlc/somniumserver/tags/persistence/TagLocalDatasource.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/tags/persistence/TagLocalDatasource.kt
@@ -4,7 +4,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.repository.CrudRepository
 import org.springframework.data.domain.Pageable
 
-interface TagRepository : CrudRepository<TagEntity, Long> {
+interface TagLocalDatasource : CrudRepository<TagEntity, Long> {
   fun findByTitle(title: String): TagEntity?
   fun findByTitleContainingIgnoreCase(title: String, pageable: Pageable): Page<TagEntity>
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/tags/persistence/TagRepository.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/tags/persistence/TagRepository.kt
@@ -1,7 +1,10 @@
 package com.infusionvlc.somniumserver.tags.persistence
 
+import org.springframework.data.domain.Page
 import org.springframework.data.repository.CrudRepository
+import org.springframework.data.domain.Pageable
 
 interface TagRepository : CrudRepository<TagEntity, Long> {
   fun findByTitle(title: String): TagEntity?
+  fun findByTitleContainingIgnoreCase(title: String, pageable: Pageable): Page<TagEntity>
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/tags/usecases/FindTagByTitle.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/tags/usecases/FindTagByTitle.kt
@@ -3,13 +3,12 @@ package com.infusionvlc.somniumserver.tags.usecases
 import arrow.core.Option
 import arrow.core.toOption
 import com.infusionvlc.somniumserver.tags.models.Tag
-import com.infusionvlc.somniumserver.tags.persistence.TagRepository
+import com.infusionvlc.somniumserver.tags.persistence.TagDAO
+import com.infusionvlc.somniumserver.tags.persistence.TagLocalDatasource
 import com.infusionvlc.somniumserver.tags.persistence.toDomain
 import org.springframework.stereotype.Component
 
 @Component
-class FindTagByTitle(private val dao: TagRepository) {
-  fun execute(title: String): Option<Tag> = Option
-    .fromNullable(dao.findByTitle(title).toOption().orNull())
-    .map { it.toDomain() }
+class FindTagByTitle(private val dao: TagDAO) {
+  fun execute(title: String): Option<Tag> = dao.findByTitle(title)
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/tags/usecases/FindTagByTitle.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/tags/usecases/FindTagByTitle.kt
@@ -1,11 +1,8 @@
 package com.infusionvlc.somniumserver.tags.usecases
 
 import arrow.core.Option
-import arrow.core.toOption
 import com.infusionvlc.somniumserver.tags.models.Tag
 import com.infusionvlc.somniumserver.tags.persistence.TagDAO
-import com.infusionvlc.somniumserver.tags.persistence.TagLocalDatasource
-import com.infusionvlc.somniumserver.tags.persistence.toDomain
 import org.springframework.stereotype.Component
 
 @Component

--- a/src/main/kotlin/com/infusionvlc/somniumserver/tags/usecases/GetOrCreateTag.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/tags/usecases/GetOrCreateTag.kt
@@ -8,9 +8,6 @@ import com.infusionvlc.somniumserver.base.toEither
 import com.infusionvlc.somniumserver.dreams.models.TagCreationErrors
 import com.infusionvlc.somniumserver.tags.models.Tag
 import com.infusionvlc.somniumserver.tags.persistence.TagDAO
-import com.infusionvlc.somniumserver.tags.persistence.TagLocalDatasource
-import com.infusionvlc.somniumserver.tags.persistence.toDomain
-import com.infusionvlc.somniumserver.tags.persistence.toEntity
 import org.springframework.stereotype.Component
 
 @Component

--- a/src/main/kotlin/com/infusionvlc/somniumserver/tags/usecases/SearchTag.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/tags/usecases/SearchTag.kt
@@ -1,18 +1,16 @@
 package com.infusionvlc.somniumserver.tags.usecases
 
 import com.infusionvlc.somniumserver.tags.models.Tag
+import com.infusionvlc.somniumserver.tags.persistence.TagDAO
 import com.infusionvlc.somniumserver.tags.persistence.TagEntity
-import com.infusionvlc.somniumserver.tags.persistence.TagRepository
+import com.infusionvlc.somniumserver.tags.persistence.TagLocalDatasource
 import com.infusionvlc.somniumserver.tags.persistence.toDomain
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
 
 @Component
 class SearchTag(
-  private val dao: TagRepository
+  private val dao: TagDAO
 ) {
-  fun execute(title: String, page: Int, pageSize: Int): List<Tag> =
-    dao.findByTitleContainingIgnoreCase(title, PageRequest.of(page, pageSize))
-      .toList()
-      .map(TagEntity::toDomain)
+  fun execute(title: String, page: Int, pageSize: Int): List<Tag> = dao.searchTag(title, page, pageSize)
 }

--- a/src/main/kotlin/com/infusionvlc/somniumserver/tags/usecases/SearchTag.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/tags/usecases/SearchTag.kt
@@ -1,0 +1,18 @@
+package com.infusionvlc.somniumserver.tags.usecases
+
+import com.infusionvlc.somniumserver.tags.models.Tag
+import com.infusionvlc.somniumserver.tags.persistence.TagEntity
+import com.infusionvlc.somniumserver.tags.persistence.TagRepository
+import com.infusionvlc.somniumserver.tags.persistence.toDomain
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Component
+
+@Component
+class SearchTag(
+  private val dao: TagRepository
+) {
+  fun execute(title: String, page: Int, pageSize: Int): List<Tag> =
+    dao.findByTitleContainingIgnoreCase(title, PageRequest.of(page, pageSize))
+      .toList()
+      .map(TagEntity::toDomain)
+}

--- a/src/main/kotlin/com/infusionvlc/somniumserver/tags/usecases/SearchTag.kt
+++ b/src/main/kotlin/com/infusionvlc/somniumserver/tags/usecases/SearchTag.kt
@@ -2,10 +2,6 @@ package com.infusionvlc.somniumserver.tags.usecases
 
 import com.infusionvlc.somniumserver.tags.models.Tag
 import com.infusionvlc.somniumserver.tags.persistence.TagDAO
-import com.infusionvlc.somniumserver.tags.persistence.TagEntity
-import com.infusionvlc.somniumserver.tags.persistence.TagLocalDatasource
-import com.infusionvlc.somniumserver.tags.persistence.toDomain
-import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
 
 @Component

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/integration/SearchTagIntegrationTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/integration/SearchTagIntegrationTest.kt
@@ -48,24 +48,24 @@ class SearchTagIntegrationTest : WordSpec() {
       givenTags()
 
       "Get Nightmare tag ig contains 'night' words" {
-        val result = restTemplate.
-          getForEntityAuthorized<Array<Tag>>("http://localhost:$port/tags/v1/search?title=night&page=0&page_size=20")
+        val result = restTemplate
+          .getForEntityAuthorized<Array<Tag>>("http://localhost:$port/tags/v1/search?title=night&page=0&page_size=20")
 
         result.statusCode shouldBe HttpStatus.OK
         result.body!!.toList() shouldContain NIGHTMARE_TAG
       }
 
       "Get all tags that cointains the letter 'a' in the title" {
-        val result = restTemplate.
-          getForEntityAuthorized<Array<Tag>>("http://localhost:$port/tags/v1/search?title=a&page=0&page_size=20")
+        val result = restTemplate
+          .getForEntityAuthorized<Array<Tag>>("http://localhost:$port/tags/v1/search?title=a&page=0&page_size=20")
 
         result.statusCode shouldBe HttpStatus.OK
         result.body!!.toList() shouldContainAll listOf(NIGHTMARE_TAG, DEJAVU_TAG)
       }
 
       "Insensitive case search" {
-        val result = restTemplate.
-          getForEntityAuthorized<Array<Tag>>("http://localhost:$port/tags/v1/search?title=lUcId&page=0&page_size=20")
+        val result = restTemplate
+          .getForEntityAuthorized<Array<Tag>>("http://localhost:$port/tags/v1/search?title=lUcId&page=0&page_size=20")
 
         result.statusCode shouldBe HttpStatus.OK
         result.body!!.toList() shouldContain LUCID_TAG

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/integration/SearchTagIntegrationTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/integration/SearchTagIntegrationTest.kt
@@ -1,0 +1,81 @@
+package com.infusionvlc.somniumserver.dreams.integration
+
+import com.infusionvlc.somniumserver.getForEntityAuthorized
+import com.infusionvlc.somniumserver.tags.models.Tag
+import com.infusionvlc.somniumserver.tags.persistence.TagEntity
+import com.infusionvlc.somniumserver.tags.persistence.TagRepository
+import com.infusionvlc.somniumserver.tags.persistence.toDomain
+import com.infusionvlc.somniumserver.users.persistence.UserRepository
+import io.kotlintest.Description
+import io.kotlintest.Spec
+import io.kotlintest.matchers.collections.shouldContain
+import io.kotlintest.matchers.collections.shouldContainAll
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.WordSpec
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.TestContextManager
+import org.springframework.test.context.junit4.SpringRunner
+
+@RunWith(SpringRunner::class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SearchTagIntegrationTest : WordSpec() {
+
+  private lateinit var NIGHTMARE_TAG: Tag
+  private lateinit var DEJAVU_TAG: Tag
+  private lateinit var LUCID_TAG: Tag
+
+  private val restTemplate = TestRestTemplate().restTemplate
+
+  @LocalServerPort
+  var port: Int = 0
+
+  @Autowired
+  lateinit var tagDao: TagRepository
+  @Autowired
+  lateinit var userDao: UserRepository
+
+  override fun beforeSpec(description: Description, spec: Spec) {
+    TestContextManager(this.javaClass).prepareTestInstance(this)
+  }
+
+  init {
+    "Search tags" should {
+      givenTags()
+
+      "Get Nightmare tag ig contains 'night' words" {
+        val result = restTemplate.
+          getForEntityAuthorized<Array<Tag>>("http://localhost:$port/tags/v1/search?title=night&page=0&page_size=20")
+
+        result.statusCode shouldBe HttpStatus.OK
+        result.body!!.toList() shouldContain NIGHTMARE_TAG
+      }
+
+      "Get all tags that cointains the letter 'a' in the title" {
+        val result = restTemplate.
+          getForEntityAuthorized<Array<Tag>>("http://localhost:$port/tags/v1/search?title=a&page=0&page_size=20")
+
+        result.statusCode shouldBe HttpStatus.OK
+        result.body!!.toList() shouldContainAll listOf(NIGHTMARE_TAG, DEJAVU_TAG)
+      }
+
+      "Insensitive case search" {
+        val result = restTemplate.
+          getForEntityAuthorized<Array<Tag>>("http://localhost:$port/tags/v1/search?title=lUcId&page=0&page_size=20")
+
+        result.statusCode shouldBe HttpStatus.OK
+        result.body!!.toList() shouldContain LUCID_TAG
+      }
+    }
+  }
+
+  fun givenTags() {
+    NIGHTMARE_TAG = tagDao.save(TagEntity(1, "Nightmare", 1234567890, 1234567890, emptyList())).toDomain()
+    DEJAVU_TAG = tagDao.save(TagEntity(2, "DejaVu", 1234567890, 1234567890, emptyList())).toDomain()
+    LUCID_TAG = tagDao.save(TagEntity(3, "Lucid", 1234567890, 1234567890, emptyList())).toDomain()
+  }
+}

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/integration/SearchTagIntegrationTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/integration/SearchTagIntegrationTest.kt
@@ -3,7 +3,7 @@ package com.infusionvlc.somniumserver.dreams.integration
 import com.infusionvlc.somniumserver.getForEntityAuthorized
 import com.infusionvlc.somniumserver.tags.models.Tag
 import com.infusionvlc.somniumserver.tags.persistence.TagEntity
-import com.infusionvlc.somniumserver.tags.persistence.TagRepository
+import com.infusionvlc.somniumserver.tags.persistence.TagLocalDatasource
 import com.infusionvlc.somniumserver.tags.persistence.toDomain
 import com.infusionvlc.somniumserver.users.persistence.UserRepository
 import io.kotlintest.Description
@@ -35,7 +35,7 @@ class SearchTagIntegrationTest : WordSpec() {
   var port: Int = 0
 
   @Autowired
-  lateinit var tagDao: TagRepository
+  lateinit var localDatasource: TagLocalDatasource
   @Autowired
   lateinit var userDao: UserRepository
 
@@ -74,8 +74,8 @@ class SearchTagIntegrationTest : WordSpec() {
   }
 
   fun givenTags() {
-    NIGHTMARE_TAG = tagDao.save(TagEntity(1, "Nightmare", 1234567890, 1234567890, emptyList())).toDomain()
-    DEJAVU_TAG = tagDao.save(TagEntity(2, "DejaVu", 1234567890, 1234567890, emptyList())).toDomain()
-    LUCID_TAG = tagDao.save(TagEntity(3, "Lucid", 1234567890, 1234567890, emptyList())).toDomain()
+    NIGHTMARE_TAG = localDatasource.save(TagEntity(1, "Nightmare", 1234567890, 1234567890, emptyList())).toDomain()
+    DEJAVU_TAG = localDatasource.save(TagEntity(2, "DejaVu", 1234567890, 1234567890, emptyList())).toDomain()
+    LUCID_TAG = localDatasource.save(TagEntity(3, "Lucid", 1234567890, 1234567890, emptyList())).toDomain()
   }
 }

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/GetOrCreateTagTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/GetOrCreateTagTest.kt
@@ -7,8 +7,6 @@ import com.infusionvlc.somniumserver.dreams.models.TagCreationErrors
 import com.infusionvlc.somniumserver.mock
 import com.infusionvlc.somniumserver.tags.models.Tag
 import com.infusionvlc.somniumserver.tags.persistence.TagDAO
-import com.infusionvlc.somniumserver.tags.persistence.TagEntity
-import com.infusionvlc.somniumserver.tags.persistence.TagLocalDatasource
 import com.infusionvlc.somniumserver.tags.usecases.FindTagByTitle
 import com.infusionvlc.somniumserver.tags.usecases.GetOrCreateTag
 import io.kotlintest.assertions.arrow.either.shouldBeLeft

--- a/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/GetOrCreateTagTest.kt
+++ b/src/test/kotlin/com/infusionvlc/somniumserver/dreams/usecases/GetOrCreateTagTest.kt
@@ -1,11 +1,14 @@
 package com.infusionvlc.somniumserver.dreams.usecases
 
 import arrow.core.Option
+import arrow.core.Try
+import com.infusionvlc.somniumserver.AnyMocker
 import com.infusionvlc.somniumserver.dreams.models.TagCreationErrors
 import com.infusionvlc.somniumserver.mock
 import com.infusionvlc.somniumserver.tags.models.Tag
+import com.infusionvlc.somniumserver.tags.persistence.TagDAO
 import com.infusionvlc.somniumserver.tags.persistence.TagEntity
-import com.infusionvlc.somniumserver.tags.persistence.TagRepository
+import com.infusionvlc.somniumserver.tags.persistence.TagLocalDatasource
 import com.infusionvlc.somniumserver.tags.usecases.FindTagByTitle
 import com.infusionvlc.somniumserver.tags.usecases.GetOrCreateTag
 import io.kotlintest.assertions.arrow.either.shouldBeLeft
@@ -15,9 +18,9 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.anyString
 
-class GetOrCreateTagTest : StringSpec() {
+class GetOrCreateTagTest : StringSpec(), AnyMocker {
 
-  private val mockDao = mock<TagRepository>()
+  private val mockDao = mock<TagDAO>()
   private val mockFindTagByTitle = mock<FindTagByTitle>()
   private val getOrCreateTag = GetOrCreateTag(mockDao, mockFindTagByTitle)
 
@@ -46,7 +49,7 @@ class GetOrCreateTagTest : StringSpec() {
     }
 
     "If the tag didn't exist and title is valid creates a new tag and return it" {
-      `when`(mockDao.save(any(TagEntity::class.java))).thenReturn(TagEntity())
+      `when`(mockDao.save(any())).thenReturn(Try.just(Tag(0, "Title", 123, 123)))
       findTagMockWillReturnEmpty()
 
       getOrCreateTag.execute("Title").shouldBeRight()


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #16

### :tophat: What is the goal?

Provide a way for the user to search tags.

### :memo: How is it being implemented?

* Create a new route `GET /tags/v1/search` wich has three parameters:
  * `title`: Title of the tag
  * `page`: Number of the search page
  * `page_size`: Size of the search results page
* Create `SearchTag` use case
* Add `findByTitleContainingIgnoreCase` method at the `TagRepository`
* Create `SearchTagIntegrationTest`

### :boom: How can it be tested?

- [ ] **Search Tag**:
  * Create a `Tag`. This could be done by creating a new Dream with a Tag, for this you can use the url `POST http://localhost:8080/dreams/v1/` with body:
```json
{
	"title": "Dream",
	"description": "Description",
	"dreamtDate": 1234567890,
	"tags": ["Tag"],
	"publc": true
}
```
  * Search the tag that you created with the new endpoint. If you created the tag using the method above call to `http://localhost:8080/tags/v1/search?title=t&page=0&page_size=10`. You should receive a response similar to:

```json
[
    {
        "id": 2,
        "title": "Tag",
        "creationDate": 1540149543378,
        "updateDate": 1540149543378
    }
]
```
  
 
### :floppy_disk: Requires DB migration?

- [X] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.  
